### PR TITLE
feat/#15 - langchain4j 를 통한 기본 assistant 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.11"
     runtimeOnly 'com.mysql:mysql-connector-j:8.3.0'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'dev.langchain4j:langchain4j:1.4.0'
+    implementation 'dev.langchain4j:langchain4j-google-ai-gemini:1.4.0'
 }
 
 configurations.configureEach {

--- a/src/main/java/com/icebreaker/be/infra/llm/assisstant/Keywords.java
+++ b/src/main/java/com/icebreaker/be/infra/llm/assisstant/Keywords.java
@@ -1,0 +1,11 @@
+package com.icebreaker.be.infra.llm.assisstant;
+
+import java.util.List;
+import jdk.jfr.Description;
+
+public record Keywords(
+        @Description("Keyword list in Korean words, not sentences")
+        List<String> values
+) {
+
+}

--- a/src/main/java/com/icebreaker/be/infra/llm/assisstant/KeywordsExtractorAssistant.java
+++ b/src/main/java/com/icebreaker/be/infra/llm/assisstant/KeywordsExtractorAssistant.java
@@ -1,0 +1,6 @@
+package com.icebreaker.be.infra.llm.assisstant;
+
+public interface KeywordsExtractorAssistant {
+
+    Keywords extract(String text);
+}

--- a/src/main/java/com/icebreaker/be/infra/llm/assisstant/Questions.java
+++ b/src/main/java/com/icebreaker/be/infra/llm/assisstant/Questions.java
@@ -1,0 +1,11 @@
+package com.icebreaker.be.infra.llm.assisstant;
+
+import dev.langchain4j.model.output.structured.Description;
+import java.util.List;
+
+public record Questions(
+        @Description("generate a list of questions consist of 5 that is related to the given user text")
+        List<String> values
+) {
+
+}

--- a/src/main/java/com/icebreaker/be/infra/llm/assisstant/QuestionsGeneratorAssistant.java
+++ b/src/main/java/com/icebreaker/be/infra/llm/assisstant/QuestionsGeneratorAssistant.java
@@ -1,0 +1,6 @@
+package com.icebreaker.be.infra.llm.assisstant;
+
+public interface QuestionsGeneratorAssistant {
+
+    Questions generate(String text);
+}

--- a/src/main/java/com/icebreaker/be/infra/llm/config/LlmConfig.java
+++ b/src/main/java/com/icebreaker/be/infra/llm/config/LlmConfig.java
@@ -1,0 +1,48 @@
+package com.icebreaker.be.infra.llm.config;
+
+import com.icebreaker.be.infra.llm.assisstant.KeywordsExtractorAssistant;
+import com.icebreaker.be.infra.llm.assisstant.QuestionsGeneratorAssistant;
+import dev.langchain4j.model.chat.Capability;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ResponseFormat;
+import dev.langchain4j.model.googleai.GoogleAiGeminiChatModel;
+import dev.langchain4j.service.AiServices;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class LlmConfig {
+
+    @Value("${gemini.api-key}")
+    private String apiKey;
+
+    @Value("${gemini.model}")
+    private String modelName;
+
+    @Bean
+    public ChatModel chatModel() {
+        return GoogleAiGeminiChatModel.builder()
+                .apiKey(apiKey)
+                .supportedCapabilities(Capability.RESPONSE_FORMAT_JSON_SCHEMA)
+                .responseFormat(ResponseFormat.JSON)
+                .modelName(modelName)
+                .build();
+    }
+
+
+    @Bean
+    public KeywordsExtractorAssistant keywordsExtractorAssistant(ChatModel chatModel) {
+        return AiServices.builder(KeywordsExtractorAssistant.class)
+                .chatModel(chatModel)
+                .build();
+    }
+
+    @Bean
+    public QuestionsGeneratorAssistant questionsGeneratorAssistant(ChatModel chatModel) {
+        return AiServices.builder(QuestionsGeneratorAssistant.class)
+                .chatModel(chatModel)
+                .build();
+    }
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -31,3 +31,7 @@ springdoc:
     path: /swagger
     tags-sorter: alpha
     operations-sorter: alpha
+
+gemini:
+  api-key: ${GEMINI_API_KEY}
+  model: ${GEMINI_MODEL:gemini-1.5-flash}


### PR DESCRIPTION
## Ref Issue
- resolve #15

기존에 Spring AI 는 vertex AI Gemini 만을 지원하고, 일반 Gemini API를 지원하지 않았기 때문에 google Gemini Sdk 를 고려했지만, 다양한 형태에서의 유틸이 부족하다고 느껴 langchain4j 를 구성하였습니다.

## Content
- 키워드 추출 Assistant 구성
- 질문 생성 Assistant 구성
- Gemini Model 및 Assistant 빈 주입

## Appendix
외부로부터 받아오는 형태이기에 이를 infra layer에 배치하였습니다.