### PR TITLE
bug/#67 - caddy가 전달하는 forward 헤더 신뢰하도록 변경

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,5 +1,6 @@
 server:
   port: ${SERVER_PORT:8080}
+  forward-headers-strategy: native
 
 spring:
   config:


### PR DESCRIPTION
### Ref Issue
- resolve #67 

### Content
- Caddy 적용 이후 forward되어오는 헤더의 미신뢰로 발생한 문제
- Caddy가 전달하는 X-Forwarded-* 헤더를 신뢰하도록 server.forward-headers-strategy: native 옵션을 추가하여, 애플리케이션이 외부 접속 주소를 올바르게 인식하도록 조치