### PR TITLE
Feat/#69 - CORS 허용URL의 Github Actions Variants(.env) 참조화

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,5 +61,6 @@ jobs:
           script: |
             cd /home/ubuntu/app
             echo "${{ secrets.APP_ENV }}" > .env
+            echo "CORS_ALLOWED_ORIGINS=${{ vars.CORS_ALLOWED_ORIGINS }}" >> .env
             chmod +x deploy.sh
             sudo ./deploy.sh ${{ github.sha }}

--- a/src/main/java/com/icebreaker/be/global/config/WebMvcConfig.java
+++ b/src/main/java/com/icebreaker/be/global/config/WebMvcConfig.java
@@ -1,7 +1,7 @@
 package com.icebreaker.be.global.config;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -10,17 +10,15 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
 
-    private static final List<String> ALLOWED_ORIGINS = List.of(
-            "http://localhost:5173",
-            "https://localhost:8080"
-    );
+    @Value("${cors.allowed-origins}")
+    private String[] ALLOWED_ORIGINS;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
                 .allowedHeaders("*")
-                .allowedOrigins(ALLOWED_ORIGINS.toArray(new String[0]))
+                .allowedOrigins(ALLOWED_ORIGINS)
                 .allowCredentials(true)
                 .maxAge(3600);
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,6 @@
+cors:
+  allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:5173,http://localhost:8080}
+
 server:
   port: ${SERVER_PORT:8080}
 


### PR DESCRIPTION
### Ref issue
- resolve #69 

### Contents
- CORS 허용 URL에 프론트엔드 서버를 추가하는 과정
- 프론트엔드서버를 하드코딩하는 대신, Github Actions의 Variants로 관리하도록 함