### PR TITLE
Refactor/#76 - 3주차 PR 리뷰 반영

### DIFF
--- a/src/main/java/com/icebreaker/be/application/waitingroom/event/WaitingRoomEventListener.java
+++ b/src/main/java/com/icebreaker/be/application/waitingroom/event/WaitingRoomEventListener.java
@@ -4,10 +4,6 @@ import com.icebreaker.be.application.room.RoomService;
 import com.icebreaker.be.domain.publisher.EventPublisher;
 import com.icebreaker.be.domain.waitingroom.WaitingRoom;
 import com.icebreaker.be.global.annotation.AsyncTransactionalEventListener;
-import com.icebreaker.be.infra.persistence.redis.message.ParticipantJoinedMessage;
-import com.icebreaker.be.infra.persistence.redis.message.PubSubMessage;
-import com.icebreaker.be.infra.persistence.redis.message.PubSubMessageType;
-import com.icebreaker.be.infra.persistence.redis.message.RoomStartedMessage;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,11 +21,7 @@ public class WaitingRoomEventListener {
     @AsyncTransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleWaitingRoomParticipantJoinedEvent(WaitingRoomParticipantJoinedEvent event) {
 
-        ParticipantJoinedMessage payload = new ParticipantJoinedMessage(event.roomId(),
-                event.waitingRoomWithParticipants());
-        PubSubMessage<ParticipantJoinedMessage> message = new PubSubMessage<>(
-                PubSubMessageType.PARTICIPANT_JOINED, payload);
-        eventPublisher.publish(message);
+        eventPublisher.publish(event);
         log.info("Publishing PARTICIPANT_JOINED message for roomId: {} publish to redis",
                 event.roomId());
     }
@@ -41,10 +33,7 @@ public class WaitingRoomEventListener {
 
         roomService.createRoom(waitingRoom, participantIds);
 
-        RoomStartedMessage payload = new RoomStartedMessage(waitingRoom.roomId());
-        PubSubMessage<RoomStartedMessage> message = new PubSubMessage<>(
-                PubSubMessageType.ROOM_STARTED, payload);
-        eventPublisher.publish(message);
+        eventPublisher.publish(event);
         log.info("Publishing ROOM_STARTED message, participantIds: {} publish to redis",
                 event.getParticipantIds());
     }

--- a/src/main/java/com/icebreaker/be/application/waitingroom/event/WaitingRoomFullEvent.java
+++ b/src/main/java/com/icebreaker/be/application/waitingroom/event/WaitingRoomFullEvent.java
@@ -1,5 +1,6 @@
 package com.icebreaker.be.application.waitingroom.event;
 
+import com.icebreaker.be.domain.publisher.DomainEvent;
 import com.icebreaker.be.domain.waitingroom.WaitingRoom;
 import com.icebreaker.be.domain.waitingroom.WaitingRoomWithParticipants;
 import com.icebreaker.be.domain.waitingroom.WaitingRoomWithParticipants.Participant;
@@ -7,7 +8,7 @@ import java.util.List;
 
 public record WaitingRoomFullEvent(
         WaitingRoomWithParticipants waitingRoomWithParticipants
-) {
+) implements DomainEvent {
 
     public WaitingRoom getWaitingRoom() {
         return waitingRoomWithParticipants.room();

--- a/src/main/java/com/icebreaker/be/application/waitingroom/event/WaitingRoomParticipantJoinedEvent.java
+++ b/src/main/java/com/icebreaker/be/application/waitingroom/event/WaitingRoomParticipantJoinedEvent.java
@@ -1,10 +1,11 @@
 package com.icebreaker.be.application.waitingroom.event;
 
+import com.icebreaker.be.domain.publisher.DomainEvent;
 import com.icebreaker.be.domain.waitingroom.WaitingRoomWithParticipants;
 
 public record WaitingRoomParticipantJoinedEvent(
         String roomId,
         WaitingRoomWithParticipants waitingRoomWithParticipants
-) {
+) implements DomainEvent {
 
 }

--- a/src/main/java/com/icebreaker/be/domain/publisher/DomainEvent.java
+++ b/src/main/java/com/icebreaker/be/domain/publisher/DomainEvent.java
@@ -1,0 +1,5 @@
+package com.icebreaker.be.domain.publisher;
+
+public interface DomainEvent {
+
+}

--- a/src/main/java/com/icebreaker/be/domain/publisher/DomainEventMapper.java
+++ b/src/main/java/com/icebreaker/be/domain/publisher/DomainEventMapper.java
@@ -1,0 +1,36 @@
+package com.icebreaker.be.domain.publisher;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.icebreaker.be.application.waitingroom.event.WaitingRoomFullEvent;
+import com.icebreaker.be.application.waitingroom.event.WaitingRoomParticipantJoinedEvent;
+import com.icebreaker.be.infra.persistence.redis.message.ParticipantJoinedMessage;
+import com.icebreaker.be.infra.persistence.redis.message.PubSubMessage;
+import com.icebreaker.be.infra.persistence.redis.message.PubSubMessageType;
+import com.icebreaker.be.infra.persistence.redis.message.RoomStartedMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DomainEventMapper {
+
+    private final ObjectMapper objectMapper;
+
+    public PubSubMessage<?> toPubSubMessage(Object event) {
+        if (event instanceof WaitingRoomParticipantJoinedEvent joinedEvent) {
+            ParticipantJoinedMessage payload = new ParticipantJoinedMessage(
+                    joinedEvent.roomId(),
+                    joinedEvent.waitingRoomWithParticipants()
+            );
+            return new PubSubMessage<>(PubSubMessageType.PARTICIPANT_JOINED, payload);
+        } else if (event instanceof WaitingRoomFullEvent fullEvent) {
+            String roomId = fullEvent.getWaitingRoom().roomId();
+            RoomStartedMessage payload = new RoomStartedMessage(roomId);
+            return new PubSubMessage<>(PubSubMessageType.ROOM_STARTED, payload);
+        } else {
+            throw new IllegalArgumentException("unsupported event type");
+        }
+    }
+}

--- a/src/main/java/com/icebreaker/be/domain/publisher/EventPublisher.java
+++ b/src/main/java/com/icebreaker/be/domain/publisher/EventPublisher.java
@@ -2,5 +2,5 @@ package com.icebreaker.be.domain.publisher;
 
 public interface EventPublisher {
 
-    void publish(Object event);
+    void publish(DomainEvent event);
 }

--- a/src/main/java/com/icebreaker/be/domain/publisher/EventPublisher.java
+++ b/src/main/java/com/icebreaker/be/domain/publisher/EventPublisher.java
@@ -1,8 +1,6 @@
 package com.icebreaker.be.domain.publisher;
 
-import com.icebreaker.be.infra.persistence.redis.message.PubSubMessage;
-
 public interface EventPublisher {
 
-    void publish(PubSubMessage<?> message);
+    void publish(Object event);
 }

--- a/src/main/java/com/icebreaker/be/infra/config/RedisConfig.java
+++ b/src/main/java/com/icebreaker/be/infra/config/RedisConfig.java
@@ -13,6 +13,8 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Configuration
 public class RedisConfig {
 
+    private final static String channelTopicName = "iceBreak";
+
     @Bean
     public RedisTemplate<String, String> customStringRedisTemplate(
             RedisConnectionFactory connectionFactory) {
@@ -28,7 +30,7 @@ public class RedisConfig {
 
     @Bean
     public ChannelTopic channelTopic() {
-        return new ChannelTopic("iceBreak");
+        return new ChannelTopic(channelTopicName);
     }
 
     @Bean

--- a/src/main/java/com/icebreaker/be/infra/config/RedisConfig.java
+++ b/src/main/java/com/icebreaker/be/infra/config/RedisConfig.java
@@ -13,7 +13,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Configuration
 public class RedisConfig {
 
-    private final static String channelTopicName = "iceBreak";
+    private static final String CHANNEL_TOPIC_NAME = "iceBreak";
 
     @Bean
     public RedisTemplate<String, String> customStringRedisTemplate(
@@ -30,7 +30,7 @@ public class RedisConfig {
 
     @Bean
     public ChannelTopic channelTopic() {
-        return new ChannelTopic(channelTopicName);
+        return new ChannelTopic(CHANNEL_TOPIC_NAME);
     }
 
     @Bean

--- a/src/main/java/com/icebreaker/be/infra/persistence/redis/handler/MessageHandler.java
+++ b/src/main/java/com/icebreaker/be/infra/persistence/redis/handler/MessageHandler.java
@@ -1,0 +1,10 @@
+package com.icebreaker.be.infra.persistence.redis.handler;
+
+import com.icebreaker.be.infra.persistence.redis.message.PubSubMessageType;
+
+public interface MessageHandler {
+
+    PubSubMessageType getMessageType();
+
+    void handleAndSend(Object payload);
+}

--- a/src/main/java/com/icebreaker/be/infra/persistence/redis/handler/MessageHandler.java
+++ b/src/main/java/com/icebreaker/be/infra/persistence/redis/handler/MessageHandler.java
@@ -1,10 +1,11 @@
 package com.icebreaker.be.infra.persistence.redis.handler;
 
+import com.icebreaker.be.infra.persistence.redis.message.MessagePayload;
 import com.icebreaker.be.infra.persistence.redis.message.PubSubMessageType;
 
 public interface MessageHandler {
 
     PubSubMessageType getMessageType();
 
-    void handleAndSend(Object payload);
+    void handleAndSend(MessagePayload payload);
 }

--- a/src/main/java/com/icebreaker/be/infra/persistence/redis/handler/MessageHandlerRegistry.java
+++ b/src/main/java/com/icebreaker/be/infra/persistence/redis/handler/MessageHandlerRegistry.java
@@ -1,0 +1,27 @@
+package com.icebreaker.be.infra.persistence.redis.handler;
+
+import com.icebreaker.be.infra.persistence.redis.message.PubSubMessageType;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MessageHandlerRegistry {
+
+    private final Map<PubSubMessageType, MessageHandler> handlerMap = new HashMap<>();
+
+    public MessageHandlerRegistry(List<MessageHandler> handlers) {
+        for (MessageHandler handler : handlers) {
+            handlerMap.put(handler.getMessageType(), handler);
+        }
+    }
+
+    public MessageHandler getHandler(PubSubMessageType messageType) {
+        MessageHandler handler = handlerMap.get(messageType);
+        if (handler == null) {
+            throw new IllegalStateException("적절한 메시지핸들러가 없습니다.");
+        }
+        return handler;
+    }
+}

--- a/src/main/java/com/icebreaker/be/infra/persistence/redis/handler/ParticipantJoinedMessageHandler.java
+++ b/src/main/java/com/icebreaker/be/infra/persistence/redis/handler/ParticipantJoinedMessageHandler.java
@@ -1,0 +1,31 @@
+package com.icebreaker.be.infra.persistence.redis.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.icebreaker.be.infra.messaging.waitingroom.WaitingRoomWebSocketNotifier;
+import com.icebreaker.be.infra.persistence.redis.message.ParticipantJoinedMessage;
+import com.icebreaker.be.infra.persistence.redis.message.PubSubMessageType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ParticipantJoinedMessageHandler implements MessageHandler {
+
+    private final WaitingRoomWebSocketNotifier waitingRoomWebSocketNotifier;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public PubSubMessageType getMessageType() {
+        return PubSubMessageType.PARTICIPANT_JOINED;
+    }
+
+    @Override
+    public void handleAndSend(Object payload) {
+        ParticipantJoinedMessage joinedPayload = objectMapper.convertValue(payload,
+                ParticipantJoinedMessage.class);
+        waitingRoomWebSocketNotifier.notifyParticipantJoined(
+                joinedPayload.getRoomId(),
+                joinedPayload.getWaitingRoomWithParticipants());
+    }
+
+}

--- a/src/main/java/com/icebreaker/be/infra/persistence/redis/handler/ParticipantJoinedMessageHandler.java
+++ b/src/main/java/com/icebreaker/be/infra/persistence/redis/handler/ParticipantJoinedMessageHandler.java
@@ -6,8 +6,10 @@ import com.icebreaker.be.infra.persistence.redis.message.MessagePayload;
 import com.icebreaker.be.infra.persistence.redis.message.ParticipantJoinedMessage;
 import com.icebreaker.be.infra.persistence.redis.message.PubSubMessageType;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ParticipantJoinedMessageHandler implements MessageHandler {
@@ -22,11 +24,16 @@ public class ParticipantJoinedMessageHandler implements MessageHandler {
 
     @Override
     public void handleAndSend(MessagePayload payload) {
-        ParticipantJoinedMessage joinedPayload = objectMapper.convertValue(payload,
-                ParticipantJoinedMessage.class);
-        waitingRoomWebSocketNotifier.notifyParticipantJoined(
-                joinedPayload.getRoomId(),
-                joinedPayload.getWaitingRoomWithParticipants());
+        try {
+            ParticipantJoinedMessage joinedPayload = objectMapper.convertValue(payload,
+                    ParticipantJoinedMessage.class);
+            waitingRoomWebSocketNotifier.notifyParticipantJoined(
+                    joinedPayload.getRoomId(),
+                    joinedPayload.getWaitingRoomWithParticipants());
+        } catch (IllegalArgumentException e) {
+            log.error("Failed to convert payload to ParticipantJoinedMessage: {}", payload, e);
+        }
+
     }
 
 }

--- a/src/main/java/com/icebreaker/be/infra/persistence/redis/handler/ParticipantJoinedMessageHandler.java
+++ b/src/main/java/com/icebreaker/be/infra/persistence/redis/handler/ParticipantJoinedMessageHandler.java
@@ -2,6 +2,7 @@ package com.icebreaker.be.infra.persistence.redis.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.icebreaker.be.infra.messaging.waitingroom.WaitingRoomWebSocketNotifier;
+import com.icebreaker.be.infra.persistence.redis.message.MessagePayload;
 import com.icebreaker.be.infra.persistence.redis.message.ParticipantJoinedMessage;
 import com.icebreaker.be.infra.persistence.redis.message.PubSubMessageType;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +21,7 @@ public class ParticipantJoinedMessageHandler implements MessageHandler {
     }
 
     @Override
-    public void handleAndSend(Object payload) {
+    public void handleAndSend(MessagePayload payload) {
         ParticipantJoinedMessage joinedPayload = objectMapper.convertValue(payload,
                 ParticipantJoinedMessage.class);
         waitingRoomWebSocketNotifier.notifyParticipantJoined(

--- a/src/main/java/com/icebreaker/be/infra/persistence/redis/handler/RoomStageChangeMessageHandler.java
+++ b/src/main/java/com/icebreaker/be/infra/persistence/redis/handler/RoomStageChangeMessageHandler.java
@@ -6,8 +6,10 @@ import com.icebreaker.be.infra.persistence.redis.message.MessagePayload;
 import com.icebreaker.be.infra.persistence.redis.message.PubSubMessageType;
 import com.icebreaker.be.infra.persistence.redis.message.RoomStageChangeMessage;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class RoomStageChangeMessageHandler implements MessageHandler {
@@ -22,9 +24,14 @@ public class RoomStageChangeMessageHandler implements MessageHandler {
 
     @Override
     public void handleAndSend(MessagePayload payload) {
-        RoomStageChangeMessage stageChangePayload = objectMapper.convertValue(payload,
-                RoomStageChangeMessage.class);
-        roomStageWebSocketNotifier.notifyRoomStageChanged(
-                stageChangePayload.getRoomCode(), stageChangePayload.getStage());
+        try {
+
+            RoomStageChangeMessage stageChangePayload = objectMapper.convertValue(payload,
+                    RoomStageChangeMessage.class);
+            roomStageWebSocketNotifier.notifyRoomStageChanged(
+                    stageChangePayload.getRoomCode(), stageChangePayload.getStage());
+        } catch (IllegalArgumentException e) {
+            log.error("Failed to convert payload to RoomStageChangeMessage: {}", payload, e);
+        }
     }
 }

--- a/src/main/java/com/icebreaker/be/infra/persistence/redis/handler/RoomStageChangeMessageHandler.java
+++ b/src/main/java/com/icebreaker/be/infra/persistence/redis/handler/RoomStageChangeMessageHandler.java
@@ -2,6 +2,7 @@ package com.icebreaker.be.infra.persistence.redis.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.icebreaker.be.infra.messaging.room.RoomStageWebSocketNotifier;
+import com.icebreaker.be.infra.persistence.redis.message.MessagePayload;
 import com.icebreaker.be.infra.persistence.redis.message.PubSubMessageType;
 import com.icebreaker.be.infra.persistence.redis.message.RoomStageChangeMessage;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +21,7 @@ public class RoomStageChangeMessageHandler implements MessageHandler {
     }
 
     @Override
-    public void handleAndSend(Object payload) {
+    public void handleAndSend(MessagePayload payload) {
         RoomStageChangeMessage stageChangePayload = objectMapper.convertValue(payload,
                 RoomStageChangeMessage.class);
         roomStageWebSocketNotifier.notifyRoomStageChanged(

--- a/src/main/java/com/icebreaker/be/infra/persistence/redis/handler/RoomStageChangeMessageHandler.java
+++ b/src/main/java/com/icebreaker/be/infra/persistence/redis/handler/RoomStageChangeMessageHandler.java
@@ -1,0 +1,29 @@
+package com.icebreaker.be.infra.persistence.redis.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.icebreaker.be.infra.messaging.room.RoomStageWebSocketNotifier;
+import com.icebreaker.be.infra.persistence.redis.message.PubSubMessageType;
+import com.icebreaker.be.infra.persistence.redis.message.RoomStageChangeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RoomStageChangeMessageHandler implements MessageHandler {
+
+    private final RoomStageWebSocketNotifier roomStageWebSocketNotifier;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public PubSubMessageType getMessageType() {
+        return PubSubMessageType.ROOM_STAGE_CHANGE;
+    }
+
+    @Override
+    public void handleAndSend(Object payload) {
+        RoomStageChangeMessage stageChangePayload = objectMapper.convertValue(payload,
+                RoomStageChangeMessage.class);
+        roomStageWebSocketNotifier.notifyRoomStageChanged(
+                stageChangePayload.getRoomCode(), stageChangePayload.getStage());
+    }
+}

--- a/src/main/java/com/icebreaker/be/infra/persistence/redis/handler/RoomStartedMessageHandler.java
+++ b/src/main/java/com/icebreaker/be/infra/persistence/redis/handler/RoomStartedMessageHandler.java
@@ -1,0 +1,28 @@
+package com.icebreaker.be.infra.persistence.redis.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.icebreaker.be.infra.messaging.waitingroom.WaitingRoomWebSocketNotifier;
+import com.icebreaker.be.infra.persistence.redis.message.PubSubMessageType;
+import com.icebreaker.be.infra.persistence.redis.message.RoomStartedMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RoomStartedMessageHandler implements MessageHandler {
+
+    private final WaitingRoomWebSocketNotifier waitingRoomWebSocketNotifier;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public PubSubMessageType getMessageType() {
+        return PubSubMessageType.ROOM_STARTED;
+    }
+
+    @Override
+    public void handleAndSend(Object payload) {
+        RoomStartedMessage startedPayload = objectMapper.convertValue(payload,
+                RoomStartedMessage.class);
+        waitingRoomWebSocketNotifier.notifyRoomStarted(startedPayload.getRoomId());
+    }
+}

--- a/src/main/java/com/icebreaker/be/infra/persistence/redis/handler/RoomStartedMessageHandler.java
+++ b/src/main/java/com/icebreaker/be/infra/persistence/redis/handler/RoomStartedMessageHandler.java
@@ -2,6 +2,7 @@ package com.icebreaker.be.infra.persistence.redis.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.icebreaker.be.infra.messaging.waitingroom.WaitingRoomWebSocketNotifier;
+import com.icebreaker.be.infra.persistence.redis.message.MessagePayload;
 import com.icebreaker.be.infra.persistence.redis.message.PubSubMessageType;
 import com.icebreaker.be.infra.persistence.redis.message.RoomStartedMessage;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +21,7 @@ public class RoomStartedMessageHandler implements MessageHandler {
     }
 
     @Override
-    public void handleAndSend(Object payload) {
+    public void handleAndSend(MessagePayload payload) {
         RoomStartedMessage startedPayload = objectMapper.convertValue(payload,
                 RoomStartedMessage.class);
         waitingRoomWebSocketNotifier.notifyRoomStarted(startedPayload.getRoomId());

--- a/src/main/java/com/icebreaker/be/infra/persistence/redis/handler/RoomStartedMessageHandler.java
+++ b/src/main/java/com/icebreaker/be/infra/persistence/redis/handler/RoomStartedMessageHandler.java
@@ -6,8 +6,10 @@ import com.icebreaker.be.infra.persistence.redis.message.MessagePayload;
 import com.icebreaker.be.infra.persistence.redis.message.PubSubMessageType;
 import com.icebreaker.be.infra.persistence.redis.message.RoomStartedMessage;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class RoomStartedMessageHandler implements MessageHandler {
@@ -22,8 +24,12 @@ public class RoomStartedMessageHandler implements MessageHandler {
 
     @Override
     public void handleAndSend(MessagePayload payload) {
-        RoomStartedMessage startedPayload = objectMapper.convertValue(payload,
-                RoomStartedMessage.class);
-        waitingRoomWebSocketNotifier.notifyRoomStarted(startedPayload.getRoomId());
+        try {
+            RoomStartedMessage startedPayload = objectMapper.convertValue(payload,
+                    RoomStartedMessage.class);
+            waitingRoomWebSocketNotifier.notifyRoomStarted(startedPayload.getRoomId());
+        } catch (IllegalArgumentException e) {
+            log.error("Failed to convert payload to RoomStartedMessage: {}", payload, e);
+        }
     }
 }

--- a/src/main/java/com/icebreaker/be/infra/persistence/redis/message/MessagePayload.java
+++ b/src/main/java/com/icebreaker/be/infra/persistence/redis/message/MessagePayload.java
@@ -1,0 +1,19 @@
+package com.icebreaker.be.infra.persistence.redis.message;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.EXTERNAL_PROPERTY,
+        property = "type"
+)
+@JsonSubTypes({
+        @Type(value = RoomStageChangeMessage.class, name = "ROOM_STAGE_CHANGE"),
+        @Type(value = ParticipantJoinedMessage.class, name = "PARTICIPANT_JOINED"),
+        @Type(value = RoomStartedMessage.class, name = "ROOM_STARTED")
+})
+public interface MessagePayload {
+
+}

--- a/src/main/java/com/icebreaker/be/infra/persistence/redis/message/ParticipantJoinedMessage.java
+++ b/src/main/java/com/icebreaker/be/infra/persistence/redis/message/ParticipantJoinedMessage.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class ParticipantJoinedMessage {
+public class ParticipantJoinedMessage implements MessagePayload {
 
     private String roomId;
     private WaitingRoomWithParticipants waitingRoomWithParticipants;

--- a/src/main/java/com/icebreaker/be/infra/persistence/redis/message/PubSubMessage.java
+++ b/src/main/java/com/icebreaker/be/infra/persistence/redis/message/PubSubMessage.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class PubSubMessage<T> {
+public class PubSubMessage<T extends MessagePayload> {
 
     private PubSubMessageType type;
     private T message;

--- a/src/main/java/com/icebreaker/be/infra/persistence/redis/message/RoomStageChangeMessage.java
+++ b/src/main/java/com/icebreaker/be/infra/persistence/redis/message/RoomStageChangeMessage.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class RoomStageChangeMessage {
+public class RoomStageChangeMessage implements MessagePayload {
 
     private String roomCode;
     private Stage stage;

--- a/src/main/java/com/icebreaker/be/infra/persistence/redis/message/RoomStartedMessage.java
+++ b/src/main/java/com/icebreaker/be/infra/persistence/redis/message/RoomStartedMessage.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class RoomStartedMessage {
+public class RoomStartedMessage implements MessagePayload {
 
     private String roomId;
 }

--- a/src/main/java/com/icebreaker/be/infra/persistence/redis/publisher/DomainEventMapper.java
+++ b/src/main/java/com/icebreaker/be/infra/persistence/redis/publisher/DomainEventMapper.java
@@ -1,22 +1,17 @@
 package com.icebreaker.be.infra.persistence.redis.publisher;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.icebreaker.be.application.waitingroom.event.WaitingRoomFullEvent;
 import com.icebreaker.be.application.waitingroom.event.WaitingRoomParticipantJoinedEvent;
 import com.icebreaker.be.infra.persistence.redis.message.ParticipantJoinedMessage;
 import com.icebreaker.be.infra.persistence.redis.message.PubSubMessage;
 import com.icebreaker.be.infra.persistence.redis.message.PubSubMessageType;
 import com.icebreaker.be.infra.persistence.redis.message.RoomStartedMessage;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class DomainEventMapper {
-
-    private final ObjectMapper objectMapper;
 
     public PubSubMessage<?> toPubSubMessage(Object event) {
         if (event instanceof WaitingRoomParticipantJoinedEvent joinedEvent) {

--- a/src/main/java/com/icebreaker/be/infra/persistence/redis/publisher/DomainEventMapper.java
+++ b/src/main/java/com/icebreaker/be/infra/persistence/redis/publisher/DomainEventMapper.java
@@ -2,6 +2,7 @@ package com.icebreaker.be.infra.persistence.redis.publisher;
 
 import com.icebreaker.be.application.waitingroom.event.WaitingRoomFullEvent;
 import com.icebreaker.be.application.waitingroom.event.WaitingRoomParticipantJoinedEvent;
+import com.icebreaker.be.domain.publisher.DomainEvent;
 import com.icebreaker.be.infra.persistence.redis.message.ParticipantJoinedMessage;
 import com.icebreaker.be.infra.persistence.redis.message.PubSubMessage;
 import com.icebreaker.be.infra.persistence.redis.message.PubSubMessageType;
@@ -13,7 +14,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class DomainEventMapper {
 
-    public PubSubMessage<?> toPubSubMessage(Object event) {
+    public PubSubMessage<?> toPubSubMessage(DomainEvent event) {
         if (event instanceof WaitingRoomParticipantJoinedEvent joinedEvent) {
             ParticipantJoinedMessage payload = new ParticipantJoinedMessage(
                     joinedEvent.roomId(),

--- a/src/main/java/com/icebreaker/be/infra/persistence/redis/publisher/DomainEventMapper.java
+++ b/src/main/java/com/icebreaker/be/infra/persistence/redis/publisher/DomainEventMapper.java
@@ -1,4 +1,4 @@
-package com.icebreaker.be.domain.publisher;
+package com.icebreaker.be.infra.persistence.redis.publisher;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.icebreaker.be.application.waitingroom.event.WaitingRoomFullEvent;

--- a/src/main/java/com/icebreaker/be/infra/persistence/redis/publisher/DomainEventMapper.java
+++ b/src/main/java/com/icebreaker/be/infra/persistence/redis/publisher/DomainEventMapper.java
@@ -26,7 +26,8 @@ public class DomainEventMapper {
             RoomStartedMessage payload = new RoomStartedMessage(roomId);
             return new PubSubMessage<>(PubSubMessageType.ROOM_STARTED, payload);
         } else {
-            throw new IllegalArgumentException("unsupported event type");
+            throw new IllegalArgumentException(
+                    "Unsupported event type: " + event.getClass().getName());
         }
     }
 }

--- a/src/main/java/com/icebreaker/be/infra/persistence/redis/publisher/RedisEventPublisher.java
+++ b/src/main/java/com/icebreaker/be/infra/persistence/redis/publisher/RedisEventPublisher.java
@@ -2,6 +2,7 @@ package com.icebreaker.be.infra.persistence.redis.publisher;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.icebreaker.be.domain.publisher.DomainEvent;
 import com.icebreaker.be.domain.publisher.EventPublisher;
 import com.icebreaker.be.infra.persistence.redis.message.PubSubMessage;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +21,7 @@ public class RedisEventPublisher implements EventPublisher {
     private final ObjectMapper objectMapper;
     private final ChannelTopic channelTopic;
 
-    public void publish(Object event) {
+    public void publish(DomainEvent event) {
         try {
             PubSubMessage<?> message = domainEventMapper.toPubSubMessage(event);
             String jsonMessage = objectMapper.writeValueAsString(message);

--- a/src/main/java/com/icebreaker/be/infra/persistence/redis/publisher/RedisEventPublisher.java
+++ b/src/main/java/com/icebreaker/be/infra/persistence/redis/publisher/RedisEventPublisher.java
@@ -2,6 +2,7 @@ package com.icebreaker.be.infra.persistence.redis.publisher;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.icebreaker.be.domain.publisher.DomainEventMapper;
 import com.icebreaker.be.domain.publisher.EventPublisher;
 import com.icebreaker.be.infra.persistence.redis.message.PubSubMessage;
 import lombok.RequiredArgsConstructor;
@@ -16,11 +17,13 @@ import org.springframework.stereotype.Component;
 public class RedisEventPublisher implements EventPublisher {
 
     private final RedisTemplate<String, String> customStringRedisTemplate;
+    private final DomainEventMapper domainEventMapper;
     private final ObjectMapper objectMapper;
     private final ChannelTopic channelTopic;
 
-    public void publish(PubSubMessage<?> message) {
+    public void publish(Object event) {
         try {
+            PubSubMessage<?> message = domainEventMapper.toPubSubMessage(event);
             String jsonMessage = objectMapper.writeValueAsString(message);
             customStringRedisTemplate.convertAndSend(channelTopic.getTopic(), jsonMessage);
             log.info("Successfully published to topic '{}': {}", channelTopic.getTopic(),

--- a/src/main/java/com/icebreaker/be/infra/persistence/redis/publisher/RedisEventPublisher.java
+++ b/src/main/java/com/icebreaker/be/infra/persistence/redis/publisher/RedisEventPublisher.java
@@ -2,7 +2,6 @@ package com.icebreaker.be.infra.persistence.redis.publisher;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.icebreaker.be.domain.publisher.DomainEventMapper;
 import com.icebreaker.be.domain.publisher.EventPublisher;
 import com.icebreaker.be.infra.persistence.redis.message.PubSubMessage;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/icebreaker/be/infra/persistence/redis/subscriber/RedisEventSubscriber.java
+++ b/src/main/java/com/icebreaker/be/infra/persistence/redis/subscriber/RedisEventSubscriber.java
@@ -1,12 +1,10 @@
 package com.icebreaker.be.infra.persistence.redis.subscriber;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.icebreaker.be.infra.messaging.room.RoomStageWebSocketNotifier;
-import com.icebreaker.be.infra.messaging.waitingroom.WaitingRoomWebSocketNotifier;
-import com.icebreaker.be.infra.persistence.redis.message.ParticipantJoinedMessage;
+import com.icebreaker.be.infra.persistence.redis.handler.MessageHandler;
+import com.icebreaker.be.infra.persistence.redis.handler.MessageHandlerRegistry;
 import com.icebreaker.be.infra.persistence.redis.message.PubSubMessage;
-import com.icebreaker.be.infra.persistence.redis.message.RoomStageChangeMessage;
-import com.icebreaker.be.infra.persistence.redis.message.RoomStartedMessage;
+import com.icebreaker.be.infra.persistence.redis.message.PubSubMessageType;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
@@ -20,9 +18,8 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class RedisEventSubscriber implements MessageListener {
 
-    private final WaitingRoomWebSocketNotifier waitingRoomWebSocketNotifier;
-    private final RoomStageWebSocketNotifier roomStageWebSocketNotifier;
     private final ObjectMapper objectMapper;
+    private final MessageHandlerRegistry registry;
 
     //Redis 채널로 들어온 메시지를 받아서, 최종적으로 사용자에게 보내야함
     @Override
@@ -31,28 +28,13 @@ public class RedisEventSubscriber implements MessageListener {
             String jsonMessage = new String(message.getBody(), StandardCharsets.UTF_8);
             PubSubMessage<?> pubSubMessage = objectMapper.readValue(jsonMessage,
                     PubSubMessage.class);
+            PubSubMessageType type = pubSubMessage.getType();
+            Object payload = pubSubMessage.getMessage();
             log.info("Received redis message: {}", jsonMessage);
-            switch (pubSubMessage.getType()) {
-                case PARTICIPANT_JOINED -> {
-                    ParticipantJoinedMessage joinedPayload = objectMapper.convertValue(
-                            pubSubMessage.getMessage(), ParticipantJoinedMessage.class);
-                    waitingRoomWebSocketNotifier.notifyParticipantJoined(
-                            joinedPayload.getRoomId(),
-                            joinedPayload.getWaitingRoomWithParticipants());
-                }
-                case ROOM_STARTED -> {
-                    RoomStartedMessage startedPayload = objectMapper.convertValue(
-                            pubSubMessage.getMessage(), RoomStartedMessage.class);
-                    waitingRoomWebSocketNotifier.notifyRoomStarted(startedPayload.getRoomId());
-                }
-                case ROOM_STAGE_CHANGE -> {
-                    RoomStageChangeMessage stageChangePayload = objectMapper.convertValue(
-                            pubSubMessage.getMessage(), RoomStageChangeMessage.class);
-                    roomStageWebSocketNotifier.notifyRoomStageChanged(
-                            stageChangePayload.getRoomCode(), stageChangePayload.getStage());
-                }
-                default -> log.info("Received unknown message type");
-            }
+
+            MessageHandler handler = registry.getHandler(pubSubMessage.getType());
+            handler.handleAndSend(pubSubMessage.getMessage());
+
             log.info("Successfully processed message for type: {}", pubSubMessage.getType());
         } catch (IOException e) {
             log.error("Failed to parse Redis message", e);

--- a/src/main/java/com/icebreaker/be/infra/persistence/redis/subscriber/RedisEventSubscriber.java
+++ b/src/main/java/com/icebreaker/be/infra/persistence/redis/subscriber/RedisEventSubscriber.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.icebreaker.be.infra.persistence.redis.handler.MessageHandler;
 import com.icebreaker.be.infra.persistence.redis.handler.MessageHandlerRegistry;
 import com.icebreaker.be.infra.persistence.redis.message.PubSubMessage;
-import com.icebreaker.be.infra.persistence.redis.message.PubSubMessageType;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
@@ -28,8 +27,6 @@ public class RedisEventSubscriber implements MessageListener {
             String jsonMessage = new String(message.getBody(), StandardCharsets.UTF_8);
             PubSubMessage<?> pubSubMessage = objectMapper.readValue(jsonMessage,
                     PubSubMessage.class);
-            PubSubMessageType type = pubSubMessage.getType();
-            Object payload = pubSubMessage.getMessage();
             log.info("Received redis message: {}", jsonMessage);
 
             MessageHandler handler = registry.getHandler(pubSubMessage.getType());

--- a/src/main/java/com/icebreaker/be/infra/persistence/redis/subscriber/RedisEventSubscriber.java
+++ b/src/main/java/com/icebreaker/be/infra/persistence/redis/subscriber/RedisEventSubscriber.java
@@ -3,6 +3,7 @@ package com.icebreaker.be.infra.persistence.redis.subscriber;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.icebreaker.be.infra.persistence.redis.handler.MessageHandler;
 import com.icebreaker.be.infra.persistence.redis.handler.MessageHandlerRegistry;
+import com.icebreaker.be.infra.persistence.redis.message.MessagePayload;
 import com.icebreaker.be.infra.persistence.redis.message.PubSubMessage;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -25,8 +26,10 @@ public class RedisEventSubscriber implements MessageListener {
     public void onMessage(Message message, byte[] pattern) {
         try {
             String jsonMessage = new String(message.getBody(), StandardCharsets.UTF_8);
-            PubSubMessage<?> pubSubMessage = objectMapper.readValue(jsonMessage,
-                    PubSubMessage.class);
+            PubSubMessage<MessagePayload> pubSubMessage = objectMapper.readValue(jsonMessage,
+                    objectMapper.getTypeFactory().constructParametricType(
+                            PubSubMessage.class, MessagePayload.class)
+            );
             log.info("Received redis message: {}", jsonMessage);
 
             MessageHandler handler = registry.getHandler(pubSubMessage.getType());

--- a/src/main/java/com/icebreaker/be/infra/persistence/redis/subscriber/RedisEventSubscriber.java
+++ b/src/main/java/com/icebreaker/be/infra/persistence/redis/subscriber/RedisEventSubscriber.java
@@ -8,6 +8,7 @@ import com.icebreaker.be.infra.persistence.redis.message.PubSubMessage;
 import com.icebreaker.be.infra.persistence.redis.message.RoomStageChangeMessage;
 import com.icebreaker.be.infra.persistence.redis.message.RoomStartedMessage;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.Message;
@@ -27,7 +28,7 @@ public class RedisEventSubscriber implements MessageListener {
     @Override
     public void onMessage(Message message, byte[] pattern) {
         try {
-            String jsonMessage = new String(message.getBody());
+            String jsonMessage = new String(message.getBody(), StandardCharsets.UTF_8);
             PubSubMessage<?> pubSubMessage = objectMapper.readValue(jsonMessage,
                     PubSubMessage.class);
             log.info("Received redis message: {}", jsonMessage);


### PR DESCRIPTION
## Ref Issue
- resolve #76

## Content
- EventPublisher가 infra계층에 의존하는 문제
    - DomainEventMapper에서 event를 pubsubMessage로 변환하도록 변경
- PubSubMessage의 타입이 늘어나면 RedisSubscriber의 코드가 복잡해지는 문제
     - MessageHandler 인터페이스와 구현체를 정의하고 이를 Registry에서 Map으로 관리하여, RedisSubscriber의 switch문을 제거
     - 이를 통해 메시지 타입에 맞는 핸들러를 이용해서 기존의 로직 처리 가능 
     

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Events are now published and routed through a domain-level flow with registry-based dispatch, simplifying message handling and configuration.
  * Standardized payload typing, UTF-8 parsing, and centralized channel configuration for more consistent runtime behavior.
* **New Features**
  * Added per-event handlers and mapping so participant joins, room starts, and stage changes are delivered reliably to real-time notifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->