### PR TITLE
Refactor/#85 - 매직상수 제거

### DIFF
--- a/src/main/java/com/icebreaker/be/global/config/AsyncConfig.java
+++ b/src/main/java/com/icebreaker/be/global/config/AsyncConfig.java
@@ -10,24 +10,32 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 @EnableAsync(proxyTargetClass = true)
 public class AsyncConfig {
 
+    private static final int LLM_CORE = 10;
+    private static final int LLM_MAX = 30;
+    private static final int LLM_QUEUE = 100;
+    private static final String LLM_PREFIX = "LLM-";
+
+    private static final int TOPIC_CORE = 5;
+    private static final int TOPIC_MAX = 10;
+    private static final int TOPIC_QUEUE = 100;
+    private static final String TOPIC_PREFIX = "topic-async-";
+
     @Bean(name = "llmExecutor")
     public Executor llmExecutor() {
-        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(10);
-        executor.setMaxPoolSize(30);
-        executor.setQueueCapacity(100);
-        executor.setThreadNamePrefix("LLM-");
-        executor.initialize();
-        return executor;
+        return createExecutor(LLM_CORE, LLM_MAX, LLM_QUEUE, LLM_PREFIX);
     }
 
     @Bean(name = "topicExecutor")
     public ThreadPoolTaskExecutor topicExecutor() {
+        return createExecutor(TOPIC_CORE, TOPIC_MAX, TOPIC_QUEUE, TOPIC_PREFIX);
+    }
+
+    private ThreadPoolTaskExecutor createExecutor(int core, int max, int queue, String prefix) {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(5);
-        executor.setMaxPoolSize(10);
-        executor.setQueueCapacity(100);
-        executor.setThreadNamePrefix("topic-async-");
+        executor.setCorePoolSize(core);
+        executor.setMaxPoolSize(max);
+        executor.setQueueCapacity(queue);
+        executor.setThreadNamePrefix(prefix);
         executor.initialize();
         return executor;
     }

--- a/src/main/java/com/icebreaker/be/global/config/SwaggerConfig.java
+++ b/src/main/java/com/icebreaker/be/global/config/SwaggerConfig.java
@@ -10,9 +10,12 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class SwaggerConfig {
 
+    private static final String LOCAL_SERVER_URL = "http://localhost:8080";
+    private static final String RELEASE_URL = "https://icebreak.click";
+
     private final List<Server> servers = List.of(
-            new Server().url("http://localhost:8080").description("로컬 개발 서버"),
-            new Server().url("http://3.37.95.91").description("EC2 배포 서버")
+            new Server().url(LOCAL_SERVER_URL).description("로컬 개발 서버"),
+            new Server().url(RELEASE_URL).description("서비스 배포 서버")
     );
 
     @Bean

--- a/src/main/java/com/icebreaker/be/global/config/WebMvcConfig.java
+++ b/src/main/java/com/icebreaker/be/global/config/WebMvcConfig.java
@@ -13,6 +13,9 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Value("${cors.allowed-origins}")
     private String[] allowedOrigins;
 
+    @Value("${cors.max-age}")
+    private long maxAge;
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
@@ -20,6 +23,6 @@ public class WebMvcConfig implements WebMvcConfigurer {
                 .allowedHeaders("*")
                 .allowedOrigins(allowedOrigins)
                 .allowCredentials(true)
-                .maxAge(3600);
+                .maxAge(maxAge);
     }
 }

--- a/src/main/java/com/icebreaker/be/global/config/WebSocketConfig.java
+++ b/src/main/java/com/icebreaker/be/global/config/WebSocketConfig.java
@@ -19,6 +19,7 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
+    private static final int DEFAULT_BROKER_TASK_POOL_SIZE = 1;
 
     private final CurrentUserArgumentResolver currentUserArgumentResolver;
     private final JwtChannelInterceptor jwtChannelInterceptor;
@@ -52,7 +53,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Bean
     public ThreadPoolTaskScheduler brokerTaskScheduler() {
         ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
-        scheduler.setPoolSize(1);
+        scheduler.setPoolSize(DEFAULT_BROKER_TASK_POOL_SIZE);
         scheduler.setThreadNamePrefix("wss-heartbeat-");
         scheduler.initialize();
         return scheduler;

--- a/src/main/java/com/icebreaker/be/infra/llm/config/LlmEmbeddingConfig.java
+++ b/src/main/java/com/icebreaker/be/infra/llm/config/LlmEmbeddingConfig.java
@@ -12,6 +12,8 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class LlmEmbeddingConfig {
 
+    private static final int EMBEDDING_DIMENSION = 384; // Dimension for AllMiniLmL6V2 model
+
     @Value("${milvus.host}")
     private String milvusHost;
 
@@ -32,7 +34,7 @@ public class LlmEmbeddingConfig {
                 .host(milvusHost)
                 .port(milvusPort)
                 .collectionName(collectionName)
-                .dimension(384)
+                .dimension(EMBEDDING_DIMENSION)
                 .build();
     }
 }

--- a/src/main/java/com/icebreaker/be/infra/llm/embedding/QuestionEmbeddingStore.java
+++ b/src/main/java/com/icebreaker/be/infra/llm/embedding/QuestionEmbeddingStore.java
@@ -19,6 +19,9 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class QuestionEmbeddingStore implements QuestionStore {
 
+    private static final double SIMILARITY_THRESHOLD = 0.719; // 경험적 설정 하이퍼파라미터 값
+    private static final double EQUALITY_THRESHOLD = 1.0;
+
     private final EmbeddingStore<TextSegment> embeddingStore;
     private final EmbeddingModel embeddingModel;
 
@@ -76,7 +79,7 @@ public class QuestionEmbeddingStore implements QuestionStore {
         return embeddingStore.search(searchRequest)
                 .matches()
                 .stream()
-                .filter(m -> m.score() > 0.719)
+                .filter(m -> m.score() > SIMILARITY_THRESHOLD)
                 .map(m -> new Question(m.embedded().text()))
                 .toList();
     }
@@ -97,6 +100,6 @@ public class QuestionEmbeddingStore implements QuestionStore {
         return embeddingStore.search(searchRequest)
                 .matches()
                 .stream()
-                .anyMatch(m -> m.score() >= 1.0);
+                .anyMatch(m -> m.score() >= EQUALITY_THRESHOLD);
     }
 }

--- a/src/main/java/com/icebreaker/be/infra/scheduler/QuestionScheduler.java
+++ b/src/main/java/com/icebreaker/be/infra/scheduler/QuestionScheduler.java
@@ -14,7 +14,7 @@ public class QuestionScheduler {
 
     private final QuestionAsyncExecutor asyncExecutor;
 
-    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "${scheduler.question.cron}", zone = "${scheduler.question.timezone}")
     public void run() {
         log.info("[QuestionScheduler] 질문 생성 스케줄 시작");
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -59,3 +59,8 @@ milvus:
   host: ${MILVUS_HOST:localhost}
   port: ${MILVUS_PORT:19530}
   collection-name: ${MILVUS_COLLECTION_NAME:questions}
+
+scheduler:
+  question:
+    cron: "0 0 0 * * *"
+    timezone: "Asia/Seoul"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,5 +1,6 @@
 cors:
   allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:5173,http://localhost:8080}
+  max-age: 3600
 
 server:
   port: ${SERVER_PORT:8080}


### PR DESCRIPTION
### Ref issue
- solve #85 

### Contents
- 각 파일에서 사용되고있던 매직상수를 `private static final`의 상수로 선언
- 변경가능성이 있는 상수는 application.yaml 파일로 분리하여 유지보수성 향상

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored internal executor configurations to improve maintainability and consistency across the application.
  * Externalized CORS timeout and scheduler timing to configuration properties, enabling environment-specific customization without code changes.
  * Centralized hardcoded configuration values into reusable constants for improved consistency.
  * Updated server URL references to use externalized configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->